### PR TITLE
Add VWAP calculator

### DIFF
--- a/pkg/vwap/doc.go
+++ b/pkg/vwap/doc.go
@@ -1,0 +1,15 @@
+// Package vwap provides a Volume-weighted average price calculator.
+//
+// # Volume-weighted average
+//
+// The volume-weighted average price (VWAP) is a technical analysis indicator
+// used on intraday charts that resets at the start of every new trading
+// session.
+//
+// It's a trading benchmark that represents the average price a security has
+// traded at throughout the day, based on both volume and price.
+//
+// See:
+//   - https://en.wikipedia.org/wiki/Volume-weighted_average_price
+//   - https://www.investopedia.com/terms/v/vwap.asp
+package vwap

--- a/pkg/vwap/vwap..go
+++ b/pkg/vwap/vwap..go
@@ -1,0 +1,115 @@
+package vwap
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/felipeblassioli/vwap/pkg/ringbuf"
+)
+
+// Calculator is a Volume-weighted average (VWAP) price calculator.
+//
+// The calculation is done within a sliding window of data points.
+type Calculator struct {
+	mu sync.Mutex
+
+	// windowWidth defines the maximum number of (Price, Quantity) pairs used
+	// for the computation of the current VWAP.
+	windowWidth int
+
+	// pqs holds all Price x Quantity values used so far for the calculation of
+	// the current VWAP.
+	pqs *ringbuf.RingBuffer[*big.Float]
+
+	// cumulativeTypicalPrice is the summation of all prices multiplied by the
+	// quantity of the traded asset used for the calculation of the current VWAP.
+	cumulativeTypicalPrice *big.Float
+
+	// qs holds all quantities used for the calculation of the current VWAP.
+	qs *ringbuf.RingBuffer[*big.Float]
+
+	// cumulativeVolume is the summation of all quantities used for the
+	// calculation of the current VWAP
+	cumulativeVolume *big.Float
+
+	// vwap is the result of the VWAP calculation for `windowWidth`
+	// (Price, Quantity) pairs.
+	vwap *big.Float
+}
+
+// By setting the desired precision to 24 or 53 and using matching rounding
+// mode (typically ToNearestEven), Float operations produce the same results
+// as the corresponding float32 or float64 IEEE-754 arithmetic for operands
+// that correspond to normal (i.e., not denormal) float32 or float64 numbers.
+// Exponent underflow and overflow lead to a 0 or an Infinity for different
+// values than IEEE-754 because Float exponents have a much larger range.
+const (
+	prec = uint(53)
+	mode = big.ToNearestEven
+	// Printing a float64 IEEE-754 type results in 16 precision digits
+	numPrecDigits = 16
+)
+
+var (
+	ErrFloatParse = floatParseError{msg: "failed to parse value into float"}
+)
+
+type floatParseError struct {
+	msg string
+	// value is the string that failed to be parsed into a big.Float
+	value string
+}
+
+func (e floatParseError) Error() string { return e.msg }
+
+// Value returns the string that failed to be parsed into a big.Float
+func (e floatParseError) Value() string { return e.value }
+
+func NewCalculator(windowWidth int) *Calculator {
+	return &Calculator{
+		windowWidth:            windowWidth,
+		pqs:                    ringbuf.NewRingBuffer[*big.Float](windowWidth),
+		cumulativeTypicalPrice: new(big.Float).SetPrec(prec).SetMode(mode),
+		qs:                     ringbuf.NewRingBuffer[*big.Float](windowWidth),
+		cumulativeVolume:       new(big.Float).SetPrec(prec).SetMode(mode),
+		vwap:                   new(big.Float).SetPrec(prec).SetMode(mode),
+	}
+}
+
+// Update receives a pair of (Price, Quantity) and calculates the new VWAP
+// value. If the number of pairs used for the calculation so far exceeds the
+// windowWidth, it discards the oldest pair from the calculation and substitutes
+// it by the received pair.
+func (c *Calculator) Update(price, quantity string) (string, error) {
+	p, ok := new(big.Float).SetPrec(prec).SetMode(mode).SetString(price)
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrFloatParse, price)
+	}
+
+	q, ok := new(big.Float).SetPrec(prec).SetMode(mode).SetString(quantity)
+	if !ok {
+		return "", fmt.Errorf("%w %s", ErrFloatParse, quantity)
+	}
+	pq := new(big.Float).SetPrec(prec).SetMode(mode).Mul(p, q)
+
+	c.mu.Lock()
+	if c.pqs.Len() == c.windowWidth {
+		oldPQ := c.pqs.PopFront()
+		c.cumulativeTypicalPrice.Sub(c.cumulativeTypicalPrice, oldPQ)
+
+		oldQ := c.qs.PopFront()
+		c.cumulativeVolume = c.cumulativeVolume.Sub(c.cumulativeVolume, oldQ)
+	}
+
+	c.cumulativeTypicalPrice.Add(c.cumulativeTypicalPrice, pq)
+	c.pqs.PushBack(pq)
+
+	c.cumulativeVolume.Add(c.cumulativeVolume, q)
+	c.qs.PushBack(q)
+
+	c.vwap.Quo(c.cumulativeTypicalPrice, c.cumulativeVolume)
+	c.mu.Unlock()
+
+	return c.vwap.Text('f', numPrecDigits), nil
+}

--- a/pkg/vwap/vwap_test.go
+++ b/pkg/vwap/vwap_test.go
@@ -1,0 +1,98 @@
+package vwap
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculator_Update(t *testing.T) {
+	t.Run("Data point parse failure", func(t *testing.T) {
+		tests := []struct {
+			price    string
+			quantity string
+		}{
+			{"not-a-float", "3.14159265359"},
+			{"3.14159265359", "not-a-float"},
+			{"1.13210a", "3.14159265359"},
+			{"3.14159265359", "1.13210.a"},
+			{"1,625", "3.14159265359"},
+			{"3.14159265359", "1,625"},
+		}
+
+		const irrelevant = 1
+		for _, tc := range tests {
+			calc := NewCalculator(irrelevant)
+
+			_, err := calc.Update(tc.price, tc.quantity)
+
+			assert.ErrorIs(t, err, ErrFloatParse)
+		}
+	})
+
+	t.Run("VWAP Calculation", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			windowWidth int
+			prices      []string
+			quantities  []string
+			vwaps       []string
+		}{
+			{
+				"Identity: window width 1",
+				1,
+				[]string{"1", "2", "3", "4", "5", "6"},
+				[]string{"2", "3", "5", "7", "11", "13"},
+				[]string{"1", "2", "3", "4", "5", "6"},
+			},
+			{
+				"Ascending Pairs: window width 2",
+				2,
+				[]string{"1", "2", "3", "4", "5", "6"},
+				[]string{"2", "3", "5", "7", "11", "13"},
+				// VWAPs: 1, 8/5, 21/8, 43/12, 83/18,
+				[]string{"1", "1.6", "2.625", "3.5833333333333335", "4.611111111111111", "5.541666666666667"},
+			},
+			{
+				"No sliding: window width equals num. of data points",
+				6,
+				[]string{"1", "2", "3", "4", "5", "6"},
+				[]string{"2", "3", "5", "7", "11", "13"},
+				// VWAPs: 1, 8/5, 23/10, 51/17, 106/28, 184/41
+				[]string{"1", "1.6", "2.3", "3", "3.7857142857142856", "4.487804878048781"},
+			},
+			{
+				"No sliding: window width bigger than num. of data points",
+				7,
+				[]string{"1", "2", "3", "4", "5", "6"},
+				[]string{"2", "3", "5", "7", "11", "13"},
+				// VWAPs: 1, 8/5, 23/10, 51/17, 106/28, 184/41
+				[]string{"1", "1.6", "2.3", "3", "3.7857142857142856", "4.487804878048781"},
+			},
+			{
+				"Descending pairs: window width 2",
+				2,
+				[]string{"6", "5", "4", "3", "2", "1"},
+				[]string{"2", "3", "5", "7", "11", "13"},
+				// VWAPs: 1, 27/5, 35/8, 41/12, 43/18, 35/24
+				[]string{"6", "5.4", "4.375", "3.4166666666666665", "2.388888888888889", "1.4583333333333333"},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				calc := NewCalculator(tc.windowWidth)
+
+				for i := 0; i < len(tc.prices); i++ {
+					vwap, _ := calc.Update(tc.prices[i], tc.quantities[i])
+
+					exp, _ := new(big.Float).SetPrec(prec).SetMode(mode).SetString(tc.vwaps[i])
+					act, _ := new(big.Float).SetPrec(prec).SetMode(mode).SetString(vwap)
+
+					assert.True(t, exp.Cmp(act) == 0, "VWAPs %v !== %v", vwap, tc.vwaps[i])
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Package `vwap` provides a Volume-weighted average price calculator.

# Volume-weighted average

The volume-weighted average price (VWAP) is a technical analysis indicator
used on intraday charts that resets at the start of every new trading
session.

It's a trading benchmark that represents the average price a security has
traded at throughout the day, based on both volume and price.

See:
  - https://en.wikipedia.org/wiki/Volume-weighted_average_price
  - https://www.investopedia.com/terms/v/vwap.asp