### PR TITLE
build: Fix lint config

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.49


### PR DESCRIPTION
Go version in `golangci-lint.yml` was v1.17 and didn't support generics.
golanci-lint version was out-dated (v1.29) and was changed to (v1.49)