### PR TITLE
fix: release application

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - main: ./cmd/foo/main.go
+  - main: ./cmd/vwap/main.go
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
The `.goreleaser.yml' configuration had the placeholder application to release. Now it will build and release `cmd/vwap`